### PR TITLE
Minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Godot 4+ specific ignores
 .godot/
+
+# Mono Specific Ignores
+.vs/

--- a/Element.cs
+++ b/Element.cs
@@ -1,3 +1,5 @@
+namespace SpacePirateGladiators;
+
 public enum Element {
     Neutral,
     Fire,

--- a/Global.cs
+++ b/Global.cs
@@ -1,5 +1,7 @@
-using Godot;
-using System;
+global using Godot;
+global using System;
+
+namespace SpacePirateGladiators;
 
 public partial class Global : Node
 {

--- a/Main.cs
+++ b/Main.cs
@@ -1,5 +1,4 @@
-using Godot;
-using System;
+namespace SpacePirateGladiators;
 
 public partial class Main : Node2D
 {

--- a/Node2D.cs
+++ b/Node2D.cs
@@ -1,5 +1,4 @@
-using Godot;
-using System;
+namespace SpacePirateGladiators;
 
 public partial class Node2D : Godot.Node2D
 {

--- a/Player.cs
+++ b/Player.cs
@@ -1,5 +1,4 @@
-using Godot;
-using System;
+namespace SpacePirateGladiators;
 
 public partial class Player : Area2D
 {

--- a/Projectile.cs
+++ b/Projectile.cs
@@ -1,5 +1,4 @@
-using Godot;
-using System;
+namespace SpacePirateGladiators;
 
 public partial class Projectile : Area2D
 {
@@ -29,18 +28,12 @@ public partial class Projectile : Area2D
 		GD.Print(Position.ToString());
 	}
 
-	public override string ToString() {
-		return $@"
-			Heading Direction: {_direction.ToString()}, 
-			Element: {_element.ToString()}, 
-			Damage: {_damage.ToString()}
+	public override string ToString() =>
+		$@"
+			Heading Direction: {_direction}, 
+			Element: {_element}, 
+			Damage: {_damage}
 		";
-	}
 
-	private void OnNoLongerVisible() {
-		QueueFree();
-	}
-
-
+	private void OnNoLongerVisible() => QueueFree();
 }
-


### PR DESCRIPTION
- Add file-scoped namespace to every script
- Convert to global usings
- Make use of arrow operator
- Remove unnecessary `.ToString()` calls